### PR TITLE
sqlflow integrate with zeppelin (SQLFlowInterpreter.java)

### DIFF
--- a/SQLFlowInterpreter.java
+++ b/SQLFlowInterpreter.java
@@ -1,0 +1,94 @@
+package org.apache.zeppelin.sqlflow;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.zeppelin.interpreter.Interpreter;
+import org.apache.zeppelin.interpreter.InterpreterContext;
+import org.apache.zeppelin.interpreter.InterpreterException;
+import org.apache.zeppelin.interpreter.InterpreterResult;
+import org.apache.zeppelin.sqlflow.client.MessageHandlerZeppelin;
+import org.sqlflow.client.SQLFlow;
+import org.apache.zeppelin.sqlflow.client.utils.EnvironmentSpecificSQLFlowClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.StringUtils;
+
+public class SQLFlowInterpreter extends Interpreter {
+	// Print Log
+	private static final Logger LOGGER = LoggerFactory
+			.getLogger(SQLFlowInterpreter.class);
+
+	private Map<String, String> parameters = new HashMap<String, String>();
+
+	public static final String SQLFLOW_SERVERADDR = "sqlflow.serverAddr";
+	public static final String MYSQL_USERNAME = "mysql.username";
+	public static final String MYSQL_PASSWORD = "mysql.password";
+	public static final String MYSQL_SERVERADDR = "mysql.serverAddr";
+	public static final String MYSQL_DATABASENAME = "mysql.databaseName";
+
+	public SQLFlowInterpreter(Properties properties) {
+		super(properties);
+	}
+
+	@Override
+	public void open() throws InterpreterException {
+		// get the configured parameters from the front page
+		String sqlflowServerAddr = getProperty(SQLFLOW_SERVERADDR);
+		String mysqlUserName = getProperty(MYSQL_USERNAME);
+		String mysqlPassword = getProperty(MYSQL_PASSWORD);
+		String mysqlAddr = getProperty(MYSQL_SERVERADDR);
+		String mysqlDatabaseName = getProperty(MYSQL_DATABASENAME);
+
+		parameters.put(SQLFLOW_SERVERADDR, sqlflowServerAddr);
+		parameters.put(MYSQL_USERNAME, mysqlUserName);
+		parameters.put(MYSQL_PASSWORD, mysqlPassword);
+		parameters.put(MYSQL_SERVERADDR, mysqlAddr);
+		parameters.put(MYSQL_DATABASENAME, mysqlDatabaseName);
+	}
+
+	@Override
+	public void cancel(InterpreterContext arg0) throws InterpreterException {
+	}
+
+	@Override
+	public void close() throws InterpreterException {
+	}
+
+	@Override
+	public FormType getFormType() throws InterpreterException {
+		return FormType.SIMPLE;
+	}
+
+	@Override
+	public int getProgress(InterpreterContext arg0) throws InterpreterException {
+		return 20;
+	}
+
+	@Override
+	public InterpreterResult interpret(String query, InterpreterContext context)
+			throws InterpreterException {
+
+		if (StringUtils.isBlank(query)) {
+			return new InterpreterResult(InterpreterResult.Code.SUCCESS);
+		}
+
+		// Create user
+		SQLFlow client = EnvironmentSpecificSQLFlowClient.getClient(
+				new MessageHandlerZeppelin(context), parameters);
+
+		// Run custom sqlflow code
+		client.run(query);
+
+		// Release user
+		try {
+			client.release();
+		} catch (InterruptedException e) {
+			LOGGER.error("", e);
+		}
+
+		return new InterpreterResult(InterpreterResult.Code.SUCCESS);
+	}
+
+}


### PR DESCRIPTION
 ## fix #3

This file is to let sqlflow inherit the interpreter interface provided by Zeppelin, so as to connect the two and realize the abstract class of Zeppelin. In this file, you can read the configuration file parameters, construct the sqlflow client, start and close the interpreter, and so on.

Create a new class named `org.Apache.Zeppelin.Sqlflow` and let it inherit from `org.Apache.Zeppelin.Interpreter.Interpreter`. Since an abstract class is inherited, constructors and overridden methods are required, with 6 methods:
```java
// Initialize interpreter
public void open();

// Close the interpreter and free resources
public void close();

// Run the interpreter and return the result. 'query' is the code entered in Zeppelin, and 'interpretercontext' is the additional running context information
public InterpreterResult interpret(String query, InterpreterContext interpreterContext);

// Canceling the run will interrupt the execution of the interpret method
public void cancel();

// For processing types of dynamic tables, please refer to: https://zeppelin.apache.org/docs/0.8.2/usage/dynamic_form/intro.html
public ForType getFormType();

// Get the running progress, the return value is 0-100
public int getProgress();
```

Among these methods, the most critical one is `public InterpreterResult interpret(String query, InterpreterContext interpreterContext)`; It is a bridge between sqlflow and Zeppelin. The collection, creation and release of user information will be realized through this method.

Examples are as follows:

```java
@Override
public InterpreterResult interpret(String query, InterpreterContext context)
		throws InterpreterException {

	if (StringUtils.isBlank(query)) {
		return new InterpreterResult(InterpreterResult.Code.SUCCESS);
	}

	// Create user
	SQLFlow client = EnvironmentSpecificSQLFlowClient.getClient(
			new MessageHandlerZeppelin(context), parameters);

	// Run custom sqlflow code
	client.run(query);

	// Release user
	try {
		client.release();
	} catch (InterruptedException e) {
		LOGGER.error("", e);
	}

	return new InterpreterResult(InterpreterResult.Code.SUCCESS);
}
```
The specific code can refer to `SQLFlowInterpreter.java`