### PR TITLE
sqlflow integrate with zeppelin (EnvironmentSpecificSQLFlowClient.java)

### DIFF
--- a/EnvironmentSpecificSQLFlowClient.java
+++ b/EnvironmentSpecificSQLFlowClient.java
@@ -1,0 +1,38 @@
+package org.apache.zeppelin.sqlflow.client.utils;
+
+import java.util.Map;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.sqlflow.client.SQLFlow;
+import org.sqlflow.client.MessageHandler;
+import proto.Sqlflow;
+
+public class EnvironmentSpecificSQLFlowClient {
+
+	public static SQLFlow getClient(MessageHandler messageHandler,
+			Map<String, String> parameters) {
+		// Get the configuration parameters from the page side
+		String serverAddr = parameters.get("sqlflow.serverAddr");
+		String submitter = "mlp";
+		String username = parameters.get("mysql.username");
+		String password = parameters.get("mysql.password");
+		String mysqlAddr = parameters.get("mysql.serverAddr");
+		String databaseName = parameters.get("mysql.databaseName");
+		String dataSource = "mysql://" + username + ":" + password + "(" + mysqlAddr
+				+ ")/" + databaseName + "?maxAllowedPacket=0";
+		String userId = "314";
+		if (StringUtils.isAnyBlank(serverAddr, submitter, dataSource, userId)) {
+			return null;
+		}
+
+		ManagedChannel chan = ManagedChannelBuilder.forTarget(serverAddr)
+				.usePlaintext().build();
+		Sqlflow.Session session = Sqlflow.Session.newBuilder()
+				.setUserId(userId).setSubmitter(submitter)
+				.setDbConnStr(dataSource).build();
+		return SQLFlow.Builder.newInstance().withSession(session)
+				.withIntervalFetching(2000).withMessageHandler(messageHandler)
+				.withChannel(chan).build();
+	}
+}


### PR DESCRIPTION
 ## fix #3

Create a class of sqlflow client. According to the parameters obtained by the foreground: database address, user name, password and other information to build a user object.

In this code document, only MySQL is used for the time being. Other SQL engines include Oracle, Hive, SparkSQL, Flink, etc. developers can expand and improve them according to their actual needs.

In the code, `submitter = "mlp"` and `userId = "314"` are equivalent to the user's user name information and ID number. This is based on the user information of login Zeppelin. Different login users have different tags. Sqlflow can identify which user is using it. A fixed value is given in the case. Developers can set the values of `submitter` and `userId` as variables, and get the corresponding parameters according to the login user information of Zeppelin.