### PR TITLE
sqlflow integrate with zeppelin (interpreter-setting.json)

### DIFF
--- a/interpreter-setting.json
+++ b/interpreter-setting.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "sqlflow",
+    "group": "sqlflow",
+    "name": "sqlflow",
+    "className": "org.apache.zeppelin.sqlflow.SQLFlowInterpreter",
+    "properties": {
+      "sqlflow.serverAddr": {
+        "envName": null,
+        "propertyName": "sqlflow.serverAddr",
+        "defaultValue": "",
+        "description": "SQLFLOW server address",
+        "type": "string"
+      },
+      "mysql.username": {
+        "envName": null,
+        "propertyName": "mysql.username",
+        "defaultValue": "",
+        "description": "The MYSQL username",
+        "type": "string"
+      },
+      "mysql.password": {
+        "envName": null,
+        "propertyName": "mysql.password",
+        "defaultValue": "",
+        "description": "The MYSQL user password",
+        "type": "password"
+      },
+      "mysql.serverAddr": {
+        "envName": null,
+        "propertyName": "mysql.serverAddr",
+        "defaultValue": "",
+        "description": "MYSQL server address",
+        "type": "string"
+      },
+      "mysql.databaseName": {
+        "envName": null,
+        "propertyName": "mysql.databaseName",
+        "defaultValue": "",
+        "description": "The MYSQL databaseName",
+        "type": "string"
+      }
+    },
+    "editor": {
+      "language": "sql",
+      "editOnDblClick": false,
+      "completionKey": "TAB"
+    }
+  }
+]


### PR DESCRIPTION
 ## fix #3

Create an interpreter configuration file.The front desk requires user input parameters, such as sqlflow service address, database service address, login user name and password, database name, etc. These need to be written in the configuration file in advance so as to be displayed on the Zeppelin front-end parameter filling page for users to fill in the corresponding parameters, and then transfer them to the background to assign the value to `"defaultValue"`.

![参数配置页面2](https://user-images.githubusercontent.com/65579930/119919617-61696580-bf9d-11eb-9027-4dbf54332e02.jpg)


